### PR TITLE
Add gecimi lyrics fetcher

### DIFF
--- a/src/nuvolakit-runner/components/lyrics/GecimiLyricsFetcher.vala
+++ b/src/nuvolakit-runner/components/lyrics/GecimiLyricsFetcher.vala
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2020 xcffl <xcffl@protonmail.com>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *    list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+namespace Nuvola {
+/**
+ * Lyric fetcher for [[http://doc.gecimi.com/en/latest/|Gecimi (Lyrics Fans) Lyrics]].
+ * Mainly Chinese and English lyrics.
+ */
+public class GecimiLyricsFetcher : GLib.Object, LyricsFetcher {
+    public Soup.Session session {get; construct set;}
+    /**
+     * URL format of Gecimi Lyrics
+     */
+    private const string SONG_API = "https://gecimi.com/api/lyric/%s/%s";
+
+    public GecimiLyricsFetcher (Soup.Session session) {
+        GLib.Object(session: session);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public async string fetch_lyrics (string artist, string song) throws LyricsError {
+        /* Fetch lrc list */
+        Soup.Message request;
+        string url = SONG_API.printf(song, artist);
+
+        request = new Soup.Message("GET", url);
+
+        SourceFunc callback = fetch_lyrics.callback;
+        session.queue_message(request, () => {
+            Idle.add((owned) callback);
+        });
+        yield;
+
+        string response = ( string ) request.response_body.flatten().data;
+        if (request.status_code != 200 || response == "") {
+            throw new LyricsError.NOT_FOUND(@"Song $song was not found on Gecimi Lyrics");
+        }
+
+        /* Get lrc content */
+        string lrc_url;
+        try {
+            lrc_url = get_lrc_url(response);
+        } catch (Error e) {
+            throw new LyricsError.PARSE_FAILED(@"Failed to handle responses for song $song from Gecimi Lyrics");
+        }
+
+        if (lrc_url == "") {
+            throw new LyricsError.NOT_FOUND(@"Song $song was not found on Gecimi Lyrics");
+        }
+        request = new Soup.Message("GET", lrc_url);
+
+        callback = fetch_lyrics.callback;
+        session.queue_message(request, () => {
+            Idle.add((owned) callback);
+        });
+        yield;
+
+        response = ( string ) request.response_body.flatten().data;
+        if (request.status_code != 200 || response == "") {
+            throw new LyricsError.NOT_FOUND(@"Song $song was not found on Gecimi Lyrics");
+        }
+
+        return response;
+    }
+
+    private string get_lrc_url (string response) throws LyricsError {
+        var parser = new Json.Parser();
+        try {
+            parser.load_from_data(response, -1);
+        } catch (Error e) {
+            throw new LyricsError.PARSE_FAILED(@"Failed to handle responses $response");
+        }
+
+        var root_object = parser.get_root().get_object();
+        var results = root_object.get_array_member("result");
+        var best_matched = results.get_elements().first().data.get_object();
+        string lrc_url = best_matched.get_string_member("lrc");
+
+        return lrc_url;
+    }
+}
+} // namespace Nuvola

--- a/src/nuvolakit-runner/components/lyrics/LyricsComponent.vala
+++ b/src/nuvolakit-runner/components/lyrics/LyricsComponent.vala
@@ -46,6 +46,7 @@ public class LyricsComponent: Component {
         SList<LyricsFetcher> fetchers = null;
         fetchers.append(new LyricsFetcherCache(app.storage.get_cache_path("lyrics")));
         fetchers.append(new AZLyricsFetcher(app.connection.session));
+        fetchers.append(new GecimiLyricsFetcher(app.connection.session));
         provider = new LyricsProvider(bindings.get_model<MediaPlayerModel>(), (owned) fetchers);
         sidebar = new LyricsSidebar(app, provider);
         unowned Sidebar app_sidebar = app.main_window.sidebar;

--- a/src/nuvolakit-runner/components/lyrics/LyricsFetcher.vala
+++ b/src/nuvolakit-runner/components/lyrics/LyricsFetcher.vala
@@ -35,7 +35,12 @@ public errordomain LyricsError {
     /**
      * Lyrics has not been found
      */
-    NOT_FOUND
+    NOT_FOUND,
+    /**
+     * Failed to handle responses from lyrics provider
+     */
+    PARSE_FAILED
+
 }
 
 


### PR DESCRIPTION
Since nuvola can't fetch lyrics of almost all Chinese songs, I add a new lyrics fetcher fetching from [gecimi's API](http://doc.gecimi.com/en/latest/).

Not really tested because it's hard to compile. Locally it warns
````
File /usr/share/vala/vapi/libsoup-2.4.vapi is read-only; trying to patch anyway
patching file libsoup-2.4.vapi (read from /usr/share/vala/vapi/libsoup-2.4.vapi)
Hunk #1 FAILED at 148.
1 out of 1 hunk FAILED -- saving rejects to file libsoup-2.4.vapi.rej
Build failed
 -> task in 'libsoup-2.4.vapi' failed with exit status 1: 
        {task 139675452411344: libsoup-2.4.vapi libsoup-2.4.vapi,libsoup-2.4.patch -> libsoup-2.4.vapi}
' patch -i /home/xcffl/Development/nuvolaruntime/vapi/libsoup-2.4.patch -o libsoup-2.4.vapi /usr/share/vala/vapi/libsoup-2.4.vapi '
````

~~On Circle CI it has `Errors during downloading metadata for repository 'updates-modular'`...~~
Well looks like Circle CI just has an outage. I'll test it later.